### PR TITLE
Fix: Doc link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   |
   <a href="mailto:contact@ploomber.io">Contact us</a>
   |
-  <a href=" https://engine.ploomber.io/en/latest/">Docs</a>
+  <a href="https://engine.ploomber.io/en/latest/">Docs</a>
   |
   <a href="https://ploomber.io/">Blog</a>
   |  


### PR DESCRIPTION
Fix Issue

<img width="888" alt="Screenshot 2023-02-03 at 5 29 14 PM" src="https://user-images.githubusercontent.com/123580782/216723576-a7fb3548-df77-4d39-9338-c7c1f76e9358.png">


<!-- readthedocs-preview ploomber-engine start -->
----
:books: Documentation preview :books:: https://ploomber-engine--40.org.readthedocs.build/en/40/

<!-- readthedocs-preview ploomber-engine end -->