### PR TITLE
Fix: track_execution parameters should be optional

### DIFF
--- a/src/ploomber_engine/tracking/tracking.py
+++ b/src/ploomber_engine/tracking/tracking.py
@@ -175,7 +175,7 @@ def track_execution(
         raise click.ClickException(
             "Missing sklearn-evaluation: pip install sklearn-evaluation"
         )
-    parameters = parameters if type(parameters) is dict else dict()
+    parameters = parameters or dict()
     nb = jupytext.read(filename)
     _, idx = find_cell_with_parameters_comment(nb)
 

--- a/src/ploomber_engine/tracking/tracking.py
+++ b/src/ploomber_engine/tracking/tracking.py
@@ -155,13 +155,13 @@ def _parse_param(value):
 
 def _parse_cli_parameters(parameters):
     if parameters is None:
-        return dict()
+        return {}
 
     pairs = [pair.strip().split("=") for pair in parameters.split(",")]
     return {k: _parse_param(v) for k, v in pairs}
 
 
-# @telemetry.log_call("track-execution")
+@telemetry.log_call("track-execution")
 def track_execution(
     filename, parameters=dict(), database="experiments.db", quiet=False
 ):

--- a/src/ploomber_engine/tracking/tracking.py
+++ b/src/ploomber_engine/tracking/tracking.py
@@ -155,14 +155,14 @@ def _parse_param(value):
 
 def _parse_cli_parameters(parameters):
     if parameters is None:
-        return {}
+        return dict()
 
     pairs = [pair.strip().split("=") for pair in parameters.split(",")]
     return {k: _parse_param(v) for k, v in pairs}
 
 
-@telemetry.log_call("track-execution")
-def track_execution(filename, parameters, database="experiments.db", quiet=False):
+# @telemetry.log_call("track-execution")
+def track_execution(filename, parameters = dict(), database="experiments.db", quiet=False):
     """
     Execute a script or notebook and write outputs to a SQLite database
     """

--- a/src/ploomber_engine/tracking/tracking.py
+++ b/src/ploomber_engine/tracking/tracking.py
@@ -162,7 +162,9 @@ def _parse_cli_parameters(parameters):
 
 
 # @telemetry.log_call("track-execution")
-def track_execution(filename, parameters = dict(), database="experiments.db", quiet=False):
+def track_execution(
+    filename, parameters=dict(), database="experiments.db", quiet=False
+):
     """
     Execute a script or notebook and write outputs to a SQLite database
     """

--- a/src/ploomber_engine/tracking/tracking.py
+++ b/src/ploomber_engine/tracking/tracking.py
@@ -163,7 +163,7 @@ def _parse_cli_parameters(parameters):
 
 @telemetry.log_call("track-execution")
 def track_execution(
-    filename, parameters=dict(), database="experiments.db", quiet=False
+    filename, parameters=None, database="experiments.db", quiet=False
 ):
     """
     Execute a script or notebook and write outputs to a SQLite database
@@ -175,7 +175,7 @@ def track_execution(
         raise click.ClickException(
             "Missing sklearn-evaluation: pip install sklearn-evaluation"
         )
-
+    parameters = parameters if type(parameters) is dict else dict()
     nb = jupytext.read(filename)
     _, idx = find_cell_with_parameters_comment(nb)
 


### PR DESCRIPTION
## CHANGES

- Add the test case for covering the `track_execution` without argument `parameter`
- Add default argument `parameter` as `dict()` in `track_execution`