### PR TITLE
running flake8 on notebooks during CI + formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ jobs:
         run: |
           flake8
 
+          # run flake8 on notebooks (.ipynb, .md, etc)
+          pip install jupytext nbqa
+          nbqa flake8 .
+
       - name: Unit tests
         run: |
           pytest --ignore=tests/test_engine.py --durations-min=5

--- a/doc/quick-start.md
+++ b/doc/quick-start.md
@@ -52,9 +52,7 @@ _ = execute_notebook("nb.ipynb", "output.ipynb", parameters=dict(x=1, y=2))
 ## Log print statements
 
 ```{code-cell} ipython3
-_ = execute_notebook("nb.ipynb", "output.ipynb",
-                     log_output=True,
-                     progress_bar=False)
+_ = execute_notebook("nb.ipynb", "output.ipynb", log_output=True, progress_bar=False)
 ```
 
 ## Plot cell's runtime

--- a/doc/user-guide/debugging/debuglater.md
+++ b/doc/user-guide/debugging/debuglater.md
@@ -45,8 +45,7 @@ Run the notebook with `debug_later=True` option (note that this notebook crashes
 
 from ploomber_engine import execute_notebook
 
-execute_notebook("debuglater-demo.ipynb", "output.ipynb",
-                 debug_later=True)
+execute_notebook("debuglater-demo.ipynb", "output.ipynb", debug_later=True)
 ```
 
 ```{admonition} Command-line equivalent

--- a/doc/user-guide/profiling/runtime.md
+++ b/doc/user-guide/profiling/runtime.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.1
+    jupytext_version: 1.14.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
@@ -53,9 +53,7 @@ Let's execute the notebook with `profile_runtime=True`
 ```{code-cell} ipython3
 from ploomber_engine import execute_notebook
 
-_ = execute_notebook("notebook.ipynb",
-                     "output",
-                     profile_runtime=True)
+_ = execute_notebook("notebook.ipynb", "output", profile_runtime=True)
 ```
 
 ## Customize plot

--- a/doc/user-guide/running.md
+++ b/doc/user-guide/running.md
@@ -72,9 +72,12 @@ If your notebook contains `print` statements and want to see them in the current
 ```
 
 ```{code-cell} ipython3
-_ = execute_notebook("running-demo.ipynb", output_path="output.ipynb",
-                     log_output=True,
-                     progress_bar=False)
+_ = execute_notebook(
+    "running-demo.ipynb",
+    output_path="output.ipynb",
+    log_output=True,
+    progress_bar=False,
+)
 ```
 
 ## Parametrizing notebooks
@@ -103,9 +106,9 @@ curl https://raw.githubusercontent.com/ploomber/ploomber-engine/main/examples/su
 If we don't pass parameters, it uses the default values:
 
 ```{code-cell} ipython3
-_ = execute_notebook("sum-demo.ipynb", output_path=None,
-                     log_output=True,
-                     progress_bar=False)
+_ = execute_notebook(
+    "sum-demo.ipynb", output_path=None, log_output=True, progress_bar=False
+)
 ```
 
 Passing `parameters` overrides the defaults:
@@ -119,7 +122,8 @@ Passing `parameters` overrides the defaults:
 
 ```{code-cell} ipython3
 _ = execute_notebook(
-    "sum-demo.ipynb", output_path=None,
+    "sum-demo.ipynb",
+    output_path=None,
     log_output=True,
     parameters=dict(x=21, y=21),
     progress_bar=False,

--- a/doc/user-guide/testing/integration.md
+++ b/doc/user-guide/testing/integration.md
@@ -43,6 +43,6 @@ namespace
 Now we can check if the variables in the notebook have the values we expected:
 
 ```{code-cell} ipython3
-assert namespace['a'] == 42
-assert namespace['b'] == 200
+assert namespace["a"] == 42
+assert namespace["b"] == 200
 ```

--- a/doc/user-guide/testing/unit.md
+++ b/doc/user-guide/testing/unit.md
@@ -43,8 +43,8 @@ definitions
 Get the `add` and `multiply` function defined in the notebook:
 
 ```{code-cell} ipython3
-add = definitions['add']
-multiply = definitions['multiply']
+add = definitions["add"]
+multiply = definitions["multiply"]
 ```
 
 Test the functions:

--- a/examples/display.ipynb
+++ b/examples/display.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "import sys\n",
     "\n",
-    "from IPython.display import HTML, display, Markdown, JSON, Javascript, Image, Latex\n",
+    "from IPython.display import HTML, display, Markdown, JSON, Image, Latex\n",
     "import matplotlib.pyplot as plt\n",
     "import pandas as pd"
    ]
@@ -73,11 +73,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "display(\n",
-    "    HTML(\n",
-    "        'this is some HTML: <a href=\"https://ploomber.io/community\">join our community!</a>'\n",
-    "    )\n",
-    ")"
+    "html = HTML(\n",
+    "    'this is some HTML: <a href=\"https://ploomber.io/community\">join our community!</a>'\n",
+    ")\n",
+    "display(html)"
    ]
   },
   {
@@ -104,7 +103,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "ploomber-engine",
    "language": "python",
    "name": "python3"
   },
@@ -118,11 +117,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9 (main, Dec 15 2022, 10:44:50) [Clang 14.0.0 (clang-1400.0.29.202)]"
+   "version": "3.10.8"
   },
   "vscode": {
    "interpreter": {
-    "hash": "b0fa6594d8f4cbf19f97940f81e996739fb7646882a419484c72d19e05852a7e"
+    "hash": "e9a38feee8a35967525e7836479294423cd64a17f54b24e1486f61aab3949499"
    }
   }
  },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,10 @@ github = "ploomber/ploomber-engine"
 
 [tool.pkgmt.check_links]
 extensions = ["md", "rst", "py", "ipynb"]
+
+
+[tool.nbqa.addopts]
+flake8 = [
+    # notebooks allow non-top imports
+    "--extend-ignore=E402",
+]


### PR DESCRIPTION
## Describe your changes

context: https://github.com/ploomber/contributing/issues/22

this PR runs flake8 on notebook files (ipynb, md) in the CI process and it formats existing notebooks

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added thorough [tests](https://github.com/ploomber/contributing/blob/main/CONTRIBUTING.md#testing) (when necessary).
- [x] I have added the right documentation in the [docstring](https://github.com/ploomber/contributing/blob/main/CONTRIBUTING.md#documenting-changes-and-new-features) and [changelog](https://github.com/ploomber/contributing/blob/main/CONTRIBUTING.md#changelog) (when needed)


<!-- readthedocs-preview ploomber-engine start -->
----
:books: Documentation preview :books:: https://ploomber-engine--43.org.readthedocs.build/en/43/

<!-- readthedocs-preview ploomber-engine end -->