### PR TITLE
Modify --save-profiling-data to accept File Path(Ploomber Engine CLI) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.0.29dev
 
+* [Feature] Supported `save_profiling_data` option with file path
+
 ## 0.0.28 (2023-04-28)
 
 *No changes. Testing the release workflow*

--- a/doc/user-guide/profiling/memory.md
+++ b/doc/user-guide/profiling/memory.md
@@ -101,7 +101,10 @@ _ = ax.set_title("My custom title")
 
 ## Saving profiling data
 
-You can save the profiling data by setting `save_profiling_data=True`.
+You can save the profiling data by setting `save_profiling_data=True`, or providing custom path to save
+### Enable save_profiling_data by setting as `True`
+
+The file will be saved as `output-profiling-data.csv` by default
 
 ```{code-cell} ipython3
 %%capture
@@ -115,3 +118,25 @@ import pandas as pd
 
 pd.read_csv("output-profiling-data.csv")
 ```
+### Enable save_profiling_data with custom file path
+
+Please be aware that the file path must end with the `.csv` format.
+
+```{code-cell} ipython3
+%%capture
+_ = execute_notebook(
+    "notebook.ipynb",
+    "output.ipynb",
+    profile_runtime=True,
+    save_profiling_data="./my_output.csv",
+)
+```
+
+```{code-cell} ipython3
+import pandas as pd
+
+pd.read_csv("my_output.csv")
+```
+
+Note: you must set `profile_memory=True` to get non-NA data 
+saved for the memory usage.

--- a/doc/user-guide/profiling/runtime.md
+++ b/doc/user-guide/profiling/runtime.md
@@ -98,7 +98,10 @@ pd.read_csv("output-profiling-data.csv")
 ```{code-cell} ipython3
 %%capture
 _ = execute_notebook(
-    "notebook.ipynb", "output.ipynb", profile_runtime=True, save_profiling_data="./my_output.csv"
+    "notebook.ipynb",
+    "output.ipynb",
+    profile_runtime=True,
+    save_profiling_data="./my_output.csv",
 )
 ```
 

--- a/doc/user-guide/profiling/runtime.md
+++ b/doc/user-guide/profiling/runtime.md
@@ -78,7 +78,9 @@ _ = ax.set_title("My custom title")
 
 You can save the profiling data by setting `save_profiling_data=True`, or providing custom path to save
 
-### Default path as `output-profiling-data.csv`, when setting `save_profiling_data=True`
+### Enable save_profiling_data by setting as `True`
+
+The file will be saved as `output-profiling-data.csv` by default
 
 ```{code-cell} ipython3
 %%capture
@@ -93,7 +95,9 @@ import pandas as pd
 pd.read_csv("output-profiling-data.csv")
 ```
 
-### Custom path, when setting `save_profiling_data={path.csv}`
+### Enable save_profiling_data with custom file path
+
+Please be aware that the file path must end with the `.csv` format.
 
 ```{code-cell} ipython3
 %%capture

--- a/doc/user-guide/profiling/runtime.md
+++ b/doc/user-guide/profiling/runtime.md
@@ -76,7 +76,9 @@ _ = ax.set_title("My custom title")
 
 ## Saving profiling data
 
-You can save the profiling data by setting `save_profiling_data=True`.
+You can save the profiling data by setting `save_profiling_data=True`, or providing custom path to save
+
+### Default path as `output-profiling-data.csv`, when setting `save_profiling_data=True`
 
 ```{code-cell} ipython3
 %%capture
@@ -89,6 +91,21 @@ _ = execute_notebook(
 import pandas as pd
 
 pd.read_csv("output-profiling-data.csv")
+```
+
+### Custom path, when setting `save_profiling_data={path.csv}`
+
+```{code-cell} ipython3
+%%capture
+_ = execute_notebook(
+    "notebook.ipynb", "output.ipynb", profile_runtime=True, save_profiling_data="./my_output.csv"
+)
+```
+
+```{code-cell} ipython3
+import pandas as pd
+
+pd.read_csv("my_output.csv")
 ```
 
 Note: you must set `profile_memory=True` to get non-NA data 

--- a/src/ploomber_engine/cli.py
+++ b/src/ploomber_engine/cli.py
@@ -6,13 +6,17 @@ import click
 
 from ploomber_engine import execute_notebook
 
+
 def handle_bool_string_option(ctx, param, value):
     if isinstance(value, bool):
         return value
     elif isinstance(value, str) and value.endswith(".csv"):
         return value
     else:
-        raise click.BadParameter('Invalid value type. Please provide either a boolean or a string.')
+        raise click.BadParameter(
+            "Invalid value type. Please provide either a boolean or a string."
+        )
+
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -106,7 +110,7 @@ def cli(
 
     $ ploomber-engine my-notebook.ipynb output.ipynb --remove-tagged-cells remove
     """
-    print ("Before: ", save_profiling_data)
+    print("Before: ", save_profiling_data)
     execute_notebook(
         input_path,
         output_path,

--- a/src/ploomber_engine/cli.py
+++ b/src/ploomber_engine/cli.py
@@ -6,6 +6,13 @@ import click
 
 from ploomber_engine import execute_notebook
 
+def handle_bool_string_option(ctx, param, value):
+    if isinstance(value, bool):
+        return value
+    elif isinstance(value, str) and value.endswith(".csv"):
+        return value
+    else:
+        raise click.BadParameter('Invalid value type. Please provide either a boolean or a string.')
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -52,6 +59,10 @@ from ploomber_engine import execute_notebook
 @click.option(
     "--save-profiling-data",
     default=False,
+    # is_flag=True,
+    # flag_value="--save-profiling-data",
+    required=False,
+    callback=handle_bool_string_option,
     type=click.UNPROCESSED,
     help="Save profiling data to a file "
     "(requires --profile-runtime and/or --profile-memory)",
@@ -95,6 +106,7 @@ def cli(
 
     $ ploomber-engine my-notebook.ipynb output.ipynb --remove-tagged-cells remove
     """
+    print ("Before: ", save_profiling_data)
     execute_notebook(
         input_path,
         output_path,

--- a/src/ploomber_engine/cli.py
+++ b/src/ploomber_engine/cli.py
@@ -52,7 +52,7 @@ from ploomber_engine import execute_notebook
 @click.option(
     "--save-profiling-data",
     default=False,
-    type=click.Path(exists=True),
+    type=click.Path(exists=False),
     help="Save profiling data to a file "
     "(requires --profile-runtime and/or --profile-memory)",
 )

--- a/src/ploomber_engine/cli.py
+++ b/src/ploomber_engine/cli.py
@@ -52,7 +52,6 @@ from ploomber_engine import execute_notebook
 @click.option(
     "--save-profiling-data",
     default=False,
-    required=False,
     type=click.UNPROCESSED,
     help="Save profiling data to a file "
     "(requires --profile-runtime and/or --profile-memory)",

--- a/src/ploomber_engine/cli.py
+++ b/src/ploomber_engine/cli.py
@@ -7,17 +7,6 @@ import click
 from ploomber_engine import execute_notebook
 
 
-def handle_bool_string_option(ctx, param, value):
-    if isinstance(value, bool):
-        return value
-    elif isinstance(value, str) and value.endswith(".csv"):
-        return value
-    else:
-        raise click.BadParameter(
-            "Invalid value type. Please provide either a boolean or a string."
-        )
-
-
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
 @click.argument("output_path", type=click.Path(exists=False))
@@ -63,10 +52,7 @@ def handle_bool_string_option(ctx, param, value):
 @click.option(
     "--save-profiling-data",
     default=False,
-    # is_flag=True,
-    # flag_value="--save-profiling-data",
     required=False,
-    callback=handle_bool_string_option,
     type=click.UNPROCESSED,
     help="Save profiling data to a file "
     "(requires --profile-runtime and/or --profile-memory)",

--- a/src/ploomber_engine/cli.py
+++ b/src/ploomber_engine/cli.py
@@ -52,7 +52,7 @@ from ploomber_engine import execute_notebook
 @click.option(
     "--save-profiling-data",
     default=False,
-    type=click.Path(exists=False),
+    type=click.UNPROCESSED,
     help="Save profiling data to a file "
     "(requires --profile-runtime and/or --profile-memory)",
 )

--- a/src/ploomber_engine/cli.py
+++ b/src/ploomber_engine/cli.py
@@ -51,9 +51,9 @@ from ploomber_engine import execute_notebook
 )
 @click.option(
     "--save-profiling-data",
-    is_flag=True,
     default=False,
-    help="Save profiling data to a file "
+    type=click.UNPROCESSED,
+    help="Save profiling data to a file"
     "(requires --profile-runtime and/or --profile-memory)",
 )
 def cli(

--- a/src/ploomber_engine/cli.py
+++ b/src/ploomber_engine/cli.py
@@ -52,8 +52,8 @@ from ploomber_engine import execute_notebook
 @click.option(
     "--save-profiling-data",
     default=False,
-    type=click.UNPROCESSED,
-    help="Save profiling data to a file"
+    type=click.Path(exists=True),
+    help="Save profiling data to a file "
     "(requires --profile-runtime and/or --profile-memory)",
 )
 def cli(

--- a/src/ploomber_engine/cli.py
+++ b/src/ploomber_engine/cli.py
@@ -95,7 +95,6 @@ def cli(
 
     $ ploomber-engine my-notebook.ipynb output.ipynb --remove-tagged-cells remove
     """
-    print("Before: ", save_profiling_data)
     execute_notebook(
         input_path,
         output_path,

--- a/src/ploomber_engine/execute.py
+++ b/src/ploomber_engine/execute.py
@@ -76,7 +76,7 @@ def execute_notebook(
 
     save_profiling_data : bool or Path, default=False
         If True, saves profiling data generated from profile_memory and profile_runtime
-        (stores a ``.csv`` file in the same folder as ``output_path``)
+        (stores a ``.csv`` file in the same folder as ``output_path``).
         If Path, saves profiling data to the given Path
 
     Returns

--- a/src/ploomber_engine/execute.py
+++ b/src/ploomber_engine/execute.py
@@ -27,7 +27,7 @@ def execute_notebook(
     profile_memory=False,
     progress_bar=True,
     debug_later=False,
-    verbose=False,
+    verbose=False, 
     remove_tagged_cells=None,
     cwd=".",
     save_profiling_data=False,
@@ -210,7 +210,7 @@ def execute_notebook(
         output_path_profiling_data = _util.sibling_with_suffix(
             output_path, "-profiling-data.csv"
         )
-        if isinstance(save_profiling_data, (str, Path)):
+        if isinstance(save_profiling_data, (str)):
             if save_profiling_data.endswith(".csv"):
                 output_path_profiling_data = save_profiling_data
             else:

--- a/src/ploomber_engine/execute.py
+++ b/src/ploomber_engine/execute.py
@@ -207,14 +207,22 @@ def execute_notebook(
 
     if save_profiling_data:
         data = profiling.get_profiling_data(out)
-        output_path_profiling_data = _util.sibling_with_suffix(
-            output_path, "-profiling-data.csv"
-        )
-        if isinstance(save_profiling_data, (str)):
+        if isinstance(save_profiling_data, str):
             if save_profiling_data.endswith(".csv"):
                 output_path_profiling_data = save_profiling_data
             else:
-                raise ValueError("The save_profiling_data path must be ended with .csv")
+                raise ValueError(
+                    "Invalid save_profiling_data, path must be ended with .csv"
+                )
+        elif isinstance(save_profiling_data, bool):
+            output_path_profiling_data = _util.sibling_with_suffix(
+                output_path, "-profiling-data.csv"
+            )
+        else:
+            raise ValueError(
+                "Invalid save_profiling_data. Please provide either a\
+ boolean or a string"
+            )
 
         with open(output_path_profiling_data, "w") as f:
             writer = csv.writer(f)

--- a/src/ploomber_engine/execute.py
+++ b/src/ploomber_engine/execute.py
@@ -133,7 +133,6 @@ def execute_notebook(
     ...                        remove_tagged_cells=["remove", "also-remove"])
     """
     path_like_input = isinstance(input_path, (str, Path))
-
     if save_profiling_data and not (profile_runtime or profile_memory):
         warnings.warn(
             "save_profiling_data=True requires "
@@ -211,12 +210,18 @@ def execute_notebook(
         output_path_profiling_data = _util.sibling_with_suffix(
             output_path, "-profiling-data.csv"
         )
+        if isinstance(save_profiling_data, (str, Path)):
+            if save_profiling_data.endswith(".csv"):
+                output_path_profiling_data = save_profiling_data
+            else:
+                raise ValueError("The save_profiling_data path must be ended with .csv")
+
         with open(output_path_profiling_data, "w") as f:
             writer = csv.writer(f)
             writer.writerow(data.keys())
             writer.writerows(zip(*data.values()))
+            print("Profiling data saved as ", output_path_profiling_data)
 
     if output_path:
         nbformat.write(out, output_path)
-
     return out

--- a/src/ploomber_engine/execute.py
+++ b/src/ploomber_engine/execute.py
@@ -74,9 +74,10 @@ def execute_notebook(
     cwd : str or Path, default='.'
         Working directory to use when executing the notebook
 
-    save_profiling_data : bool, default=False
+    save_profiling_data : bool or Path, default=False
         If True, saves profiling data generated from profile_memory and profile_runtime
         (stores a ``.csv`` file in the same folder as ``output_path``)
+        If Path, saves profiling data to the given Path
 
     Returns
     -------

--- a/src/ploomber_engine/execute.py
+++ b/src/ploomber_engine/execute.py
@@ -214,7 +214,7 @@ def execute_notebook(
                 output_path_profiling_data = save_profiling_data
             else:
                 raise ValueError(
-                    "Invalid save_profiling_data, path must be ended with .csv"
+                    "Invalid save_profiling_data, path must end with .csv"
                 )
         # Default save_profiling_data path
         elif isinstance(save_profiling_data, bool):

--- a/src/ploomber_engine/execute.py
+++ b/src/ploomber_engine/execute.py
@@ -27,7 +27,7 @@ def execute_notebook(
     profile_memory=False,
     progress_bar=True,
     debug_later=False,
-    verbose=False, 
+    verbose=False,
     remove_tagged_cells=None,
     cwd=".",
     save_profiling_data=False,

--- a/src/ploomber_engine/execute.py
+++ b/src/ploomber_engine/execute.py
@@ -213,9 +213,7 @@ def execute_notebook(
             if save_profiling_data.endswith(".csv"):
                 output_path_profiling_data = save_profiling_data
             else:
-                raise ValueError(
-                    "Invalid save_profiling_data, path must end with .csv"
-                )
+                raise ValueError("Invalid save_profiling_data, path must end with .csv")
         # Default save_profiling_data path
         elif isinstance(save_profiling_data, bool):
             output_path_profiling_data = _util.sibling_with_suffix(

--- a/src/ploomber_engine/execute.py
+++ b/src/ploomber_engine/execute.py
@@ -207,6 +207,7 @@ def execute_notebook(
 
     if save_profiling_data:
         data = profiling.get_profiling_data(out)
+        # Customized save_profiling_data path
         if isinstance(save_profiling_data, str):
             if save_profiling_data.endswith(".csv"):
                 output_path_profiling_data = save_profiling_data
@@ -214,6 +215,7 @@ def execute_notebook(
                 raise ValueError(
                     "Invalid save_profiling_data, path must be ended with .csv"
                 )
+        # Default save_profiling_data path
         elif isinstance(save_profiling_data, bool):
             output_path_profiling_data = _util.sibling_with_suffix(
                 output_path, "-profiling-data.csv"
@@ -228,7 +230,6 @@ def execute_notebook(
             writer = csv.writer(f)
             writer.writerow(data.keys())
             writer.writerows(zip(*data.values()))
-            print("Profiling data saved as ", output_path_profiling_data)
 
     if output_path:
         nbformat.write(out, output_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -138,3 +138,31 @@ def test_cli_progress_bar(tmp_empty):
 )
 def test_parse_cli_notebook_parameters(params, expected):
     assert cli._parse_cli_notebook_parameters(params) == expected
+
+
+@pytest.mark.parametrize(
+    "saved_path",
+    [
+        "./abc",
+        "./abc.py",
+        "./abc.txt",
+        "./abc.png",
+    ],
+)
+def test_cli_save_profiling_not_valid_path(tmp_empty, saved_path):
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        [
+            "nb.ipynb",
+            "out.ipynb",
+            "--profile-runtime",
+            f"--save-profiling-data={saved_path}",
+        ],
+    )
+    assert result.exit_code == 2
+    assert (
+        f"Error: Invalid value for '--save-profiling-data':\
+ Path '{saved_path}' does not exist."
+        in result.output
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -162,4 +162,6 @@ def test_cli_save_profiling_not_valid_path(tmp_empty, saved_path):
         ],
     )
     # assert result.exit_code == 2
-    assert "^^" in (result.output)
+    # print ("result.output: ", result.exception)
+    assert isinstance(result.exception, ValueError)
+    assert "must be ended" in str(result.exception)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,7 +32,8 @@ def _make_call(**kwargs):
     "cli_args, call_expected",
     [
         [
-            ["nb.ipynb", "out.ipynb", "--profile-runtime", "--save-profiling-data"],
+            ["nb.ipynb", "out.ipynb", "--profile-runtime", "--save-profiling-data",
+              True],
             _make_call(profile_runtime=True, save_profiling_data=True),
         ],
         [
@@ -85,6 +86,9 @@ def test_cli(tmp_empty, monkeypatch, cli_args, call_expected):
 
     runner = CliRunner()
     result = runner.invoke(cli.cli, cli_args)
+
+    print ("result.exception: ", result.exception)
+    print ("result.output: ", result.output)
 
     assert result.exit_code == 0
     assert mock.call_args_list == [call_expected]
@@ -161,7 +165,7 @@ def test_cli_save_profiling_not_valid_path(tmp_empty, saved_path):
             f"--save-profiling-data={saved_path}",
         ],
     )
-    # assert result.exit_code == 2
-    # print ("result.output: ", result.exception)
-    assert isinstance(result.exception, ValueError)
-    assert "must be ended" in str(result.exception)
+    assert result.exit_code == 2
+    print ("result.output: ", result.output)
+    # assert isinstance(result.exception, ValueError)
+    # assert "must be ended" in str(result)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -151,22 +151,22 @@ def test_parse_cli_notebook_parameters(params, expected):
     [
         (
             "./abc",
-            "Invalid save_profiling_data, path must be ended with .csv",
+            "Invalid save_profiling_data, path must end with .csv",
             ValueError,
         ),
         (
             "./abc.py",
-            "Invalid save_profiling_data, path must be ended with .csv",
+            "Invalid save_profiling_data, path must end with .csv",
             ValueError,
         ),
         (
             "./abc.txt",
-            "Invalid save_profiling_data, path must be ended with .csv",
+            "Invalid save_profiling_data, path must end with .csv",
             ValueError,
         ),
         (
             "./abc.png",
-            "Invalid save_profiling_data, path must be ended with .csv",
+            "Invalid save_profiling_data, path must end with .csv",
             ValueError,
         ),
         (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,8 +32,13 @@ def _make_call(**kwargs):
     "cli_args, call_expected",
     [
         [
-            ["nb.ipynb", "out.ipynb", "--profile-runtime", "--save-profiling-data",
-              True],
+            [
+                "nb.ipynb",
+                "out.ipynb",
+                "--profile-runtime",
+                "--save-profiling-data",
+                True,
+            ],
             _make_call(profile_runtime=True, save_profiling_data=True),
         ],
         [
@@ -87,8 +92,8 @@ def test_cli(tmp_empty, monkeypatch, cli_args, call_expected):
     runner = CliRunner()
     result = runner.invoke(cli.cli, cli_args)
 
-    print ("result.exception: ", result.exception)
-    print ("result.output: ", result.output)
+    print("result.exception: ", result.exception)
+    print("result.output: ", result.output)
 
     assert result.exit_code == 0
     assert mock.call_args_list == [call_expected]
@@ -166,6 +171,6 @@ def test_cli_save_profiling_not_valid_path(tmp_empty, saved_path):
         ],
     )
     assert result.exit_code == 2
-    print ("result.output: ", result.output)
+    print("result.output: ", result.output)
     # assert isinstance(result.exception, ValueError)
     # assert "must be ended" in str(result)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -150,6 +150,7 @@ def test_parse_cli_notebook_parameters(params, expected):
     ],
 )
 def test_cli_save_profiling_not_valid_path(tmp_empty, saved_path):
+    _make_nb(["1 + 1"])
     runner = CliRunner()
     result = runner.invoke(
         cli.cli,
@@ -160,9 +161,5 @@ def test_cli_save_profiling_not_valid_path(tmp_empty, saved_path):
             f"--save-profiling-data={saved_path}",
         ],
     )
-    assert result.exit_code == 2
-    assert (
-        f"Error: Invalid value for '--save-profiling-data':\
- Path '{saved_path}' does not exist."
-        in result.output
-    )
+    # assert result.exit_code == 2
+    assert "^^" in (result.output)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -150,6 +150,11 @@ def test_parse_cli_notebook_parameters(params, expected):
     "saved_path, exception_msg, exception_type",
     [
         (
+            "abc",
+            "Invalid save_profiling_data, path must end with .csv",
+            ValueError,
+        ),
+        (
             "./abc",
             "Invalid save_profiling_data, path must end with .csv",
             ValueError,
@@ -170,18 +175,8 @@ def test_parse_cli_notebook_parameters(params, expected):
             ValueError,
         ),
         (
-            float(123.0),
-            "Invalid save_profiling_data. Please provide either a boolean or a string",
-            ValueError,
-        ),
-        (
-            {"brand": "Ford"},
-            "Invalid save_profiling_data. Please provide either a boolean or a string",
-            ValueError,
-        ),
-        (
-            (1, 2, 3, 4),
-            "Invalid save_profiling_data. Please provide either a boolean or a string",
+            "./abc",
+            "Invalid save_profiling_data, path must end with .csv",
             ValueError,
         ),
     ],

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -237,6 +237,7 @@ def test_execute_notebook_save_profiling_data(
         assert len(data) == 3, "File should have 3 columns"
         assert data[2] != "NA", "memory is profiled and should not be NA"
 
+
 @pytest.mark.parametrize(
     "saved_path, exception_msg, exception_type",
     [
@@ -287,15 +288,18 @@ def test_execute_notebook_save_profiling_data(
         ),
     ],
 )
-def test_execute_notebook_invalid_save_profiling_data(saved_path, exception_msg, exception_type):
+def test_execute_notebook_invalid_save_profiling_data(
+    saved_path, exception_msg, exception_type
+):
     nb_in = _make_nb(["1 + 1"])
     with pytest.raises(exception_type, match=exception_msg):
         execute_notebook(
-        nb_in,
-        "out.ipynb",
-        save_profiling_data=saved_path,
-        profile_runtime=True,
-    )
+            nb_in,
+            "out.ipynb",
+            save_profiling_data=saved_path,
+            profile_runtime=True,
+        )
+
 
 def test_execute_notebook_different_cwd(tmp_empty):
     # setup

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -180,15 +180,15 @@ def test_execute_notebook_remove_tagged_cells(tmp_empty):
 
     assert [c.source for c in out.cells] == ["1 + 1"]
 
-
-def test_execute_notebook_save_profiling_data(tmp_empty):
+@pytest.mark.parametrize("save_profiling_data_value, save_profiling_output", [(True, "out-profiling-data.csv"), ("test.csv", "test.csv")])
+def test_execute_notebook_save_profiling_data(tmp_empty, save_profiling_data_value, save_profiling_output):
     nb_in = _make_nb(["1 + 1"])
     with pytest.warns(UserWarning, match="save_profiling_data=True requires"):
         # save_profiling_data requires profile_runtime and/or profile_memory
-        execute_notebook(nb_in, "out.ipynb", save_profiling_data=True)
+        execute_notebook(nb_in, "out.ipynb", save_profiling_data=save_profiling_data_value)
 
-    execute_notebook(nb_in, "out.ipynb", save_profiling_data=True, profile_runtime=True)
-    outfile = "out-profiling-data.csv"
+    execute_notebook(nb_in, "out.ipynb", save_profiling_data=save_profiling_data_value, profile_runtime=True)
+    outfile = save_profiling_output
     assert Path(outfile).is_file()
     with open(outfile, "r") as f:
         read_lines = f.readlines()
@@ -206,11 +206,11 @@ def test_execute_notebook_save_profiling_data(tmp_empty):
     execute_notebook(
         nb_in,
         "out.ipynb",
-        save_profiling_data=True,
+        save_profiling_data=save_profiling_data_value,
         profile_runtime=True,
         profile_memory=True,
     )
-    outfile = "out-profiling-data.csv"
+    outfile = save_profiling_output
     with open(outfile, "r") as f:
         read_lines = f.readlines()
         lines = []

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -237,6 +237,65 @@ def test_execute_notebook_save_profiling_data(
         assert len(data) == 3, "File should have 3 columns"
         assert data[2] != "NA", "memory is profiled and should not be NA"
 
+@pytest.mark.parametrize(
+    "saved_path, exception_msg, exception_type",
+    [
+        (
+            "abc",
+            "Invalid save_profiling_data, path must end with .csv",
+            ValueError,
+        ),
+        (
+            "./abc",
+            "Invalid save_profiling_data, path must end with .csv",
+            ValueError,
+        ),
+        (
+            "./abc.py",
+            "Invalid save_profiling_data, path must end with .csv",
+            ValueError,
+        ),
+        (
+            "./abc.txt",
+            "Invalid save_profiling_data, path must end with .csv",
+            ValueError,
+        ),
+        (
+            "./abc.png",
+            "Invalid save_profiling_data, path must end with .csv",
+            ValueError,
+        ),
+        (
+            "./abc",
+            "Invalid save_profiling_data, path must end with .csv",
+            ValueError,
+        ),
+        (
+            float(123.0),
+            "Invalid save_profiling_data. Please provide either a boolean or a string",
+            ValueError,
+        ),
+        (
+            {"test": "test123"},
+            "Invalid save_profiling_data. Please provide either a boolean or a string",
+            ValueError,
+        ),
+        (
+            set(["test", "test123"]),
+            "Invalid save_profiling_data. Please provide either a boolean or a string",
+            ValueError,
+        ),
+    ],
+)
+def test_execute_notebook_invalid_save_profiling_data(saved_path, exception_msg, exception_type):
+    nb_in = _make_nb(["1 + 1"])
+    with pytest.raises(exception_type, match=exception_msg):
+        execute_notebook(
+        nb_in,
+        "out.ipynb",
+        save_profiling_data=saved_path,
+        profile_runtime=True,
+    )
 
 def test_execute_notebook_different_cwd(tmp_empty):
     # setup

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -180,14 +180,27 @@ def test_execute_notebook_remove_tagged_cells(tmp_empty):
 
     assert [c.source for c in out.cells] == ["1 + 1"]
 
-@pytest.mark.parametrize("save_profiling_data_value, save_profiling_output", [(True, "out-profiling-data.csv"), ("test.csv", "test.csv")])
-def test_execute_notebook_save_profiling_data(tmp_empty, save_profiling_data_value, save_profiling_output):
+
+@pytest.mark.parametrize(
+    "save_profiling_data_value, save_profiling_output",
+    [(True, "out-profiling-data.csv"), ("test.csv", "test.csv")],
+)
+def test_execute_notebook_save_profiling_data(
+    tmp_empty, save_profiling_data_value, save_profiling_output
+):
     nb_in = _make_nb(["1 + 1"])
     with pytest.warns(UserWarning, match="save_profiling_data=True requires"):
         # save_profiling_data requires profile_runtime and/or profile_memory
-        execute_notebook(nb_in, "out.ipynb", save_profiling_data=save_profiling_data_value)
+        execute_notebook(
+            nb_in, "out.ipynb", save_profiling_data=save_profiling_data_value
+        )
 
-    execute_notebook(nb_in, "out.ipynb", save_profiling_data=save_profiling_data_value, profile_runtime=True)
+    execute_notebook(
+        nb_in,
+        "out.ipynb",
+        save_profiling_data=save_profiling_data_value,
+        profile_runtime=True,
+    )
     outfile = save_profiling_output
     assert Path(outfile).is_file()
     with open(outfile, "r") as f:


### PR DESCRIPTION
## Describe your changes

Now `save_profiling_data` can take Path string, also the existing bool usage will be supported as well.

Changes:
- Enhance `save_profiling_data` option to accept Path
- Updates doc in [API Reference](https://ploomber-engine--78.org.readthedocs.build/en/78/api/api.html?highlight=save_profiling_data#execute-notebook), [Memory usage](https://ploomber-engine--78.org.readthedocs.build/en/78/user-guide/profiling/memory.html) and [Cell runtime](https://ploomber-engine--78.org.readthedocs.build/en/78/user-guide/profiling/runtime.html)

<img width="821" alt="Screenshot 2023-05-31 at 3 27 45 PM" src="https://github.com/ploomber/ploomber-engine/assets/123580782/4e0191fd-9c1e-4de2-b87e-9be3fe7f284b">


## Issue number

Closes #65

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [x] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview ploomber-engine start -->
----
:books: Documentation preview :books:: https://ploomber-engine--78.org.readthedocs.build/en/78/

<!-- readthedocs-preview ploomber-engine end -->